### PR TITLE
Do a pivot_root() when changing to new rootfs

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -123,7 +123,7 @@ static void set_rootfs(char *rootfs)
     else if (!S_ISDIR(buf.st_mode))
         error("'%s' isn't a directory\n", rootfs);
 
-    config.rootfs = rootfs;
+    config.rootfs = canonicalize_file_name(rootfs);
 }
 
 const char rootfs_usage[] = "\


### PR DESCRIPTION
Propossal fix for issue #3.

Change implementation to actually do a pivot_root() when
getting into new rootfs. Otherwise the old rootfs mount
is not actually moved to a location where it can be
unmounted correctly, which leads to dangling mounts
from the parent.

In particular, this fixes issues with automounted
filesystems that can't correctly expire/unmount
while a ckains process is running.
